### PR TITLE
Increment pyroute2 version from 0.4.13 to 0.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 schema==0.6.5
-pyroute2==0.4.13
+pyroute2==0.5.2
 pyyaml>=4.2b1
 docopt==0.6.2


### PR DESCRIPTION
This allows for using ypconfig on Debian 10 systems.

I am successfully running ypconfig with this change.

Closes #12